### PR TITLE
fix: prevent OOM when loading multi-file OpenAPI specs

### DIFF
--- a/src/helpers/document-loader/__fixtures__/models.yaml
+++ b/src/helpers/document-loader/__fixtures__/models.yaml
@@ -1,0 +1,34 @@
+openapi: 3.1.0
+info:
+  title: Shared Models
+  version: 0.1.0
+paths: {}
+components:
+  schemas:
+    Address:
+      title: Address
+      type: object
+      properties:
+        line1: { type: string }
+        city: { type: string }
+
+    Company:
+      title: Company
+      type: object
+      properties:
+        name: { type: string }
+        address:
+          $ref: '#/components/schemas/Address'
+        status:
+          $ref: '#/components/schemas/CompanyStatus'
+
+    CompanyStatus:
+      title: CompanyStatus
+      type: string
+      enum: [PENDING, APPROVED, REJECTED]
+
+    CompanyList:
+      title: CompanyList
+      type: array
+      items:
+        $ref: '#/components/schemas/Company'

--- a/src/helpers/document-loader/__fixtures__/multi-file-api.yaml
+++ b/src/helpers/document-loader/__fixtures__/multi-file-api.yaml
@@ -1,0 +1,63 @@
+openapi: 3.1.0
+info:
+  title: Multi File API
+  version: 0.1.0
+paths:
+  /companies:
+    get:
+      operationId: listCompanies
+      responses:
+        '200':
+          description: List of companies
+          content:
+            application/json:
+              schema:
+                $ref: 'models.yaml#/components/schemas/CompanyList'
+    post:
+      operationId: createCompany
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'models.yaml#/components/schemas/Company'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: 'models.yaml#/components/schemas/Company'
+  /companies/{id}:
+    get:
+      operationId: getCompany
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Company detail
+          content:
+            application/json:
+              schema:
+                $ref: 'models.yaml#/components/schemas/Company'
+    put:
+      operationId: updateCompany
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'models.yaml#/components/schemas/Company'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: 'models.yaml#/components/schemas/Company'

--- a/src/helpers/document-loader/load.spec.ts
+++ b/src/helpers/document-loader/load.spec.ts
@@ -1,0 +1,59 @@
+import 'ts-array-extensions';
+import type { JsonMap } from '@laurence79/ts-json';
+import path from 'path';
+import { load } from './load';
+
+const fixture = (name: string) => path.join(__dirname, '__fixtures__', name);
+
+describe('load', () => {
+  describe('multi-file $ref resolution', () => {
+    it('inlines cross-file schemas into the root document', async () => {
+      const doc = (await load(fixture('multi-file-api.yaml'))) as JsonMap;
+      const components = doc.components as JsonMap;
+      const schemas = components.schemas as JsonMap;
+
+      expect(schemas.Company).toBeDefined();
+      expect(schemas.CompanyList).toBeDefined();
+      expect(schemas.Address).toBeDefined();
+      expect(schemas.CompanyStatus).toBeDefined();
+    });
+
+    it('rewrites $ref to point to local schemas', async () => {
+      const doc = (await load(fixture('multi-file-api.yaml'))) as JsonMap;
+      const paths = doc.paths as JsonMap;
+      const companies = paths['/companies'] as JsonMap;
+      const get = companies.get as JsonMap;
+      const responses = get.responses as JsonMap;
+      const ok = responses['200'] as JsonMap;
+      const content = ok.content as JsonMap;
+      const json = content['application/json'] as JsonMap;
+      const schema = json.schema as JsonMap;
+
+      expect(schema.$ref).toMatch(/#\/components\/schemas\/CompanyList$/);
+    });
+
+    it('does not create nested components trees under inlined schemas', async () => {
+      const doc = (await load(fixture('multi-file-api.yaml'))) as JsonMap;
+      const components = doc.components as JsonMap;
+      const schemas = components.schemas as JsonMap;
+
+      for (const [, schema] of Object.entries(schemas)) {
+        expect(schema).not.toHaveProperty('components');
+      }
+    });
+
+    it('inlines each external schema only once regardless of reference count', async () => {
+      const doc = (await load(fixture('multi-file-api.yaml'))) as JsonMap;
+      const components = doc.components as JsonMap;
+      const schemas = components.schemas as JsonMap;
+
+      const schemaNames = Object.keys(schemas).sort();
+      expect(schemaNames).toEqual([
+        'Address',
+        'Company',
+        'CompanyList',
+        'CompanyStatus'
+      ]);
+    });
+  });
+});

--- a/src/helpers/document-loader/load.ts
+++ b/src/helpers/document-loader/load.ts
@@ -172,6 +172,7 @@ export const load = async (source: string, logger?: Logger): Promise<Json> => {
     JsonMap;
 
   const walked: string[] = [];
+  const inlinedRefs = new Set<string>();
 
   const walkFn = async (node: JsonMap, ptr: string) => {
     if (!isReference(node) || walked.includes(ptr)) {
@@ -198,11 +199,18 @@ export const load = async (source: string, logger?: Logger): Promise<Json> => {
         return new Reference(`#/components/${key}/${title}`, filename);
       })();
 
-      jsonPointer.set(doc, newRef.pointer, refNode);
-
       node.$ref = newRef.$;
 
-      await AsyncJsonWalker.walk(doc, walkFn, newRef.pointer);
+      const canonicalKey = ref.$;
+
+      if (!inlinedRefs.has(canonicalKey)) {
+        inlinedRefs.add(canonicalKey);
+
+        const cloned = JSON.parse(JSON.stringify(refNode)) as JsonMap;
+        jsonPointer.set(doc, newRef.pointer, cloned);
+
+        await AsyncJsonWalker.walk(cloned, walkFn, newRef.pointer);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- Fixes a JavaScript heap out of memory crash when generating code from OpenAPI specs that use cross-file `$ref` references (e.g. `models.yaml#/components/schemas/Foo`)
- The document loader's inlining logic re-inlined the same external schemas under new pointer paths for every reference encountered, creating an exponentially growing document structure
- Adds deduplication by canonical reference key, deep-clones external schemas before insertion, and walks only the cloned subtree

## Root cause

When the loader encounters a cross-file `$ref`, it copies the referenced schema into the root document at `#/components/schemas/<title>` and recursively walks the copy to resolve nested refs. However:

1. **No deduplication**: the `walked` array tracked pointer paths in the root document, not canonical external schema identities. The same external schema was inlined and walked once per unique pointer path where it was referenced.
2. **Shared object references**: `refNode` was inserted by reference (not cloned), so the cached external document was mutated by subsequent walks.
3. **Walking from the root**: `AsyncJsonWalker.walk(doc, walkFn, newRef.pointer)` could discover sibling schemas added by previous inlines, causing cascading re-processing.

With ~70 shared schemas referenced from ~35 endpoints, this created nested `components/schemas` trees (e.g. `/components/schemas/CompanyStatus/components/schemas/ApproverList/components/schemas/...`) growing without bound until OOM at ~4GB.

## Fix

- Added `inlinedRefs` Set to track `filename#pointer` pairs that have already been inlined — each external schema is copied and walked exactly once
- `JSON.parse(JSON.stringify(refNode))` deep-clones the node before inserting, preventing mutation of the cached source document
- Walk the cloned subtree directly rather than from a pointer path within `doc`

## Testing

- Added `load.spec.ts` with 4 tests covering multi-file `$ref` resolution
- Added test fixtures (`models.yaml` + `multi-file-api.yaml`) exercising cross-file refs from multiple endpoints
- Verified against a production spec with 70+ schemas and 35+ endpoints — completes in <1s (previously OOM'd at 4GB)
- Existing v2 (swagger.json + user.json) example still generates correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core OpenAPI document-loading/inlining logic; mistakes could break `$ref` rewriting or schema placement for multi-file specs, though changes are scoped and covered by new tests.
> 
> **Overview**
> Prevents runaway growth/OOM when loading multi-file OpenAPI specs by **deduplicating cross-file `$ref` inlining** and avoiding repeated reinsertion of the same external schema.
> 
> `load()` now tracks already-inlined canonical refs, deep-clones referenced nodes before inserting into the root document, and walks only the cloned subtree; new fixtures and `load.spec.ts` tests assert schemas are inlined once, `$ref`s are rewritten locally, and no nested `components` trees are produced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bb3be9b9623a3dd973de176cec6f9916cfbd7c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->